### PR TITLE
REF: use periodictable as primary atomic formula data source

### DIFF
--- a/ioc-satt-dev/calculator.py
+++ b/ioc-satt-dev/calculator.py
@@ -288,7 +288,10 @@ def get_absorption_table(formula: str,
         dependency.
     """
     if atomic_weight is None:
-        atomic_weight = periodictable.formula(formula).mass
+        try:
+            atomic_weight = filter_data[formula]['atomic_weight']
+        except KeyError:
+            atomic_weight = periodictable.formula(formula).mass
 
     if density is None:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+caproto>=0.5.2
+scipy
+periodictable


### PR DESCRIPTION
Note that periodictable does not have the option for specifying crystal
structure; e.g., `periodictable.C.density` is that of graphite
(2.2g/cm^3) and not diamond (3.51g/cm^3). as indicated by the original
constant Raj used.