### PR TITLE
ENH: add preliminary autosave-like features

### DIFF
--- a/ioc-satt-dev/__main__.py
+++ b/ioc-satt-dev/__main__.py
@@ -29,5 +29,4 @@ if __name__ == '__main__':
         desc=IOCMain.__doc__)
 
     ioc = create_ioc(**ioc_args, **ioc_options)
-
     run(ioc.pvdb, **run_options)

--- a/ioc-satt-dev/__main__.py
+++ b/ioc-satt-dev/__main__.py
@@ -1,6 +1,3 @@
-import os
-import pathlib
-
 from caproto.server import ioc_arg_parser, run
 
 from .satt_app import IOCMain, create_ioc
@@ -11,7 +8,6 @@ num_blades = 18
 eV_name = "LCLS:HXR:BEAM:EV"
 pmps_run_name = "PMPS:HXR:AT2L0:RUN"
 pmps_tdes_name = "PMPS:HXR:AT2L0:T_DES"
-config_path = pathlib.Path(os.environ.get('ATT_CONFIG_PATH', '../../'))
 ################################################
 
 ioc_args = {

--- a/ioc-satt-dev/db/autosave.py
+++ b/ioc-satt-dev/db/autosave.py
@@ -1,0 +1,172 @@
+import json
+import logging
+import logging.handlers
+import pathlib
+
+import caproto
+import caproto.server
+from caproto.server import pvproperty
+
+
+def get_autosave_fields(pvprop):
+    """Get all autosaved fields from a pvproperty."""
+    for name in (pvprop.pvspec.autosave.get('fields', None) or []):
+        field = getattr(pvprop.field_inst, name, None)
+        if field is not None:
+            yield name, field.value
+
+
+class AutosaveHelper(caproto.server.PVGroup):
+    filename = 'autosave.json'
+    period = 30
+
+    autosave_hook = pvproperty(read_only=True, name=':__autosave_hook__')
+
+    @autosave_hook.startup
+    async def autosave_hook(self, instance, async_lib):
+        """
+        A startup hook which lives until the IOC exits.
+
+        Initially restores values from the autosave file `self.filename`, then
+        periodically - at `self.period` seconds - saves autosave data to
+        `self.filename`.
+        """
+        await self.restore_from_file(self.filename)
+        while True:
+            await async_lib.library.sleep(self.period)
+
+            handler = logging.handlers.RotatingFileHandler(
+                self.filename,
+                mode='wt',
+                backupCount=5,
+            )
+
+            handler.stream.close()
+            # TODO: only rotate after a day or something
+            handler.doRollover()
+            await self.save(handler.stream)
+            handler.stream.flush()
+
+    def find_autosave_properties(self):
+        """Yield (pvname, pvprop) for all tagged with `autosaved`."""
+        for pvname, pvprop in self.parent.pvdb.items():
+            try:
+                autosave = pvprop.pvspec.autosave
+            except AttributeError:
+                continue
+
+            if autosave:
+                yield pvname, pvprop
+
+    def prepare_data(self):
+        """Generate the autosave dictionary."""
+        return {
+            pvname: {'value': pvprop.value,
+                     'fields': dict(get_autosave_fields(pvprop))
+                     }
+            for pvname, pvprop in self.find_autosave_properties()
+        }
+
+    async def restore_from_file(self, filename):
+        """Restore from the autosave file."""
+        filename = pathlib.Path(filename)
+        if not filename.exists():
+            self.log.warning('Autosave file does not exist: %s', filename)
+            return
+
+        try:
+            with open(filename, 'rt') as f:
+                data = json.load(f)
+        except Exception:
+            self.log.exception('Failed to load JSON from %s', filename)
+            return
+
+        try:
+            await self.restore_values(data)
+        except Exception:
+            self.log.exception('Failed to restore values from %s', filename)
+            return
+
+    async def restore_values(self, data):
+        """Restore given the autosave file ``data`` dictionary."""
+        for pvname, info in data.items():
+            try:
+                pvprop = self.parent.pvdb[pvname]
+            except KeyError:
+                self.log.error('Autosave pvname not in database: %s', pvname)
+                continue
+
+            try:
+                await pvprop.write(info['value'])
+            except Exception as ex:
+                self.log.exception('Autosave restore failed: %s %s', pvname,
+                                   ex)
+            else:
+                self.log.info('Restored %s => %s', pvname, pvprop.value)
+
+            fields = info.get('fields', None) or {}
+            for field_name, field_value in fields.items():
+                try:
+                    field = getattr(pvprop.field_inst, field_name)
+                    await field.write(field_value)
+                except Exception as ex:
+                    self.log.exception(
+                        'Autosave restore failed: %s field %s = %s %s', pvname,
+                        field_name, field_value, ex)
+                else:
+                    self.log.info('Restored %s field %s => %s', pvname,
+                                  field_name, field.value)
+
+    async def save(self, stream, data=None):
+        """Save autosave ``data`` dictionary to the stream."""
+        if data is None:
+            data = self.prepare_data()
+
+        json.dump(data, stream)
+
+
+class AutosavedPVSpec(caproto.server.PVSpec):
+    """A hack to enhance the inflexible PVSpec with autosave settings."""
+    autosave = None
+
+    def _replace(self, **kwargs):
+        # NOTE: a further hack: this is a feature from `namedtuple` that's used
+        # to replace item(s) in the tuple, returning a newly modified copy.
+        # Here, we attach on `autosave` settings after performing the replace.
+        replaced = super()._replace(**kwargs)
+        replaced.autosave = self.autosave
+        return replaced
+
+
+def autosaved(pvprop, fields=None):
+    """
+    `pvproperty` wrapper which tags it as something that should be autosaved.
+
+    Parameters
+    ----------
+    pvprop : pvproperty
+        The pvproperty to wrap.
+
+    fields : list, optional
+        The list of fields to save, if using records.
+
+    Returns
+    -------
+    pvproperty
+        The pvproperty passed in.
+
+    Example
+    -------
+
+    ::
+        value = autosaved(pvproperty(1.0))
+    """
+
+    if fields is None:
+        fields = {'description'}
+
+    # A hack to enhance the inflexible PVSpec:
+    pvspec = AutosavedPVSpec(**pvprop.pvspec._asdict())
+    pvspec.autosave = {'fields': fields}
+    pvprop.pvspec = pvspec
+    return pvprop

--- a/ioc-satt-dev/db/filters.py
+++ b/ioc-satt-dev/db/filters.py
@@ -2,6 +2,7 @@ from caproto import ChannelType
 from caproto.server import PVGroup, pvproperty
 
 from .. import calculator
+from .autosave import autosaved
 
 
 class FilterGroup(PVGroup):
@@ -33,30 +34,37 @@ class FilterGroup(PVGroup):
         }
         self.log.info("Absorption table successfully loaded.")
 
-    material = pvproperty(value='Si',
-                          name='MATERIAL',
-                          record='stringin',
-                          doc='Filter material',
-                          dtype=ChannelType.STRING)
+    material = autosaved(
+        pvproperty(value='Si',
+                   name='MATERIAL',
+                   record='stringin',
+                   doc='Filter material',
+                   dtype=ChannelType.STRING
+                   )
+    )
 
     @material.putter
     async def material(self, instance, value):
         self.load_data(formula=value)
 
-    thickness = pvproperty(value=1E-6,
-                           name='THICKNESS',
-                           record='ao',
-                           upper_ctrl_limit=1.0,
-                           lower_ctrl_limit=0.0,
-                           doc='Filter thickness',
-                           units='m')
+    thickness = autosaved(
+        pvproperty(value=1E-6,
+                   name='THICKNESS',
+                   record='ao',
+                   upper_ctrl_limit=1.0,
+                   lower_ctrl_limit=0.0,
+                   doc='Filter thickness',
+                   units='m')
+    )
 
-    is_stuck = pvproperty(value='False',
-                          name='IS_STUCK',
-                          record='bo',
-                          enum_strings=['False', 'True'],
-                          doc='Filter is stuck in place',
-                          dtype=ChannelType.ENUM)
+    is_stuck = autosaved(
+        pvproperty(value='False',
+                   name='IS_STUCK',
+                   record='bo',
+                   enum_strings=['False', 'True'],
+                   doc='Filter is stuck in place',
+                   dtype=ChannelType.ENUM)
+    )
 
     closest_eV = pvproperty(name='CLOSE_EV',
                             read_only=True)

--- a/ioc-satt-dev/db/filters.py
+++ b/ioc-satt-dev/db/filters.py
@@ -21,18 +21,14 @@ class FilterGroup(PVGroup):
         Load the HDF5 dataset containing physical constants
         and photon energy : atomic scattering factor table.
         """
-        self.log.info("Loading absorption table for %s...", formula)
-        self.table = calculator.get_absorption_table(formula=formula)
-        self.eV_min = self.table[0, 0]
-        self.eV_max = self.table[-1, 0]
-        self.eV_inc = (self.eV_max - self.eV_min) / len(self.table[:, 0])
-        self.table_kwargs = {
-            'eV_min': self.eV_min,
-            'eV_max': self.eV_max,
-            'eV_inc': self.eV_inc,
-            'table': self.table
-        }
-        self.log.info("Absorption table successfully loaded.")
+        try:
+            self.table = calculator.get_absorption_table(formula=formula)
+        except Exception:
+            self.table = None
+            self.log.exception("Failed to load absorption table for %s",
+                               formula)
+        else:
+            self.log.info("Loaded absorption table for %s", formula)
 
     material = autosaved(
         pvproperty(value='Si',

--- a/ioc-satt-dev/db/filters.py
+++ b/ioc-satt-dev/db/filters.py
@@ -8,14 +8,20 @@ class FilterGroup(PVGroup):
     """
     PV group for filter metadata.
     """
+    def __init__(self, prefix, *, ioc, index, **kwargs):
+        super().__init__(prefix, **kwargs)
+        self.ioc = ioc
+        self.index = index
+        # Default to silicon, for now
+        self.load_data('Si')
 
-    async def load_data(self, instance, value):
+    def load_data(self, formula):
         """
         Load the HDF5 dataset containing physical constants
         and photon energy : atomic scattering factor table.
         """
-        self.log.info("Loading absorption table for %s...", value)
-        self.table = calculator.get_absorption_table(formula=value)
+        self.log.info("Loading absorption table for %s...", formula)
+        self.table = calculator.get_absorption_table(formula=formula)
         self.eV_min = self.table[0, 0]
         self.eV_max = self.table[-1, 0]
         self.eV_inc = (self.eV_max - self.eV_min) / len(self.table[:, 0])
@@ -26,20 +32,22 @@ class FilterGroup(PVGroup):
             'table': self.table
         }
         self.log.info("Absorption table successfully loaded.")
-        return value
 
     material = pvproperty(value='Si',
-                          put=load_data,
                           name='MATERIAL',
                           record='stringin',
                           doc='Filter material',
                           dtype=ChannelType.STRING)
 
+    @material.putter
+    async def material(self, instance, value):
+        self.load_data(formula=value)
+
     thickness = pvproperty(value=1E-6,
                            name='THICKNESS',
                            record='ao',
-                           upper_alarm_limit=1.0,
-                           lower_alarm_limit=0.0,
+                           upper_ctrl_limit=1.0,
+                           lower_ctrl_limit=0.0,
                            doc='Filter thickness',
                            units='m')
 
@@ -58,8 +66,8 @@ class FilterGroup(PVGroup):
 
     @pvproperty(name='T',
                 value=0.5,
-                upper_alarm_limit=1.0,
-                lower_alarm_limit=0.0,
+                upper_ctrl_limit=1.0,
+                lower_ctrl_limit=0.0,
                 read_only=True)
     async def transmission(self, instance):
         return self.get_transmission(
@@ -76,11 +84,6 @@ class FilterGroup(PVGroup):
             3 * self.current_photon_energy,
             self.thickness.value)
 
-    def __init__(self, prefix, *, ioc, index, **kwargs):
-        super().__init__(prefix, **kwargs)
-        self.ioc = ioc
-        self.index = index
-
     @property
     def current_photon_energy(self):
         """Current photon energy in eV."""
@@ -94,24 +97,6 @@ class FilterGroup(PVGroup):
 
     @thickness.putter
     async def thickness(self, instance, value):
-        if value < 0:
-            raise ValueError('Thickness must be a positive number')
         await self.transmission.write(
             self.get_transmission(self.current_photon_energy, value)
         )
-
-    @material.startup
-    async def material(self, instance, value):
-        await instance.write("Si")
-
-    @closest_eV.startup
-    async def closest_eV(self, instance, value):
-        closest_eV, _ = calculator.find_closest_energy(
-            self.current_photon_energy, self.table)
-        await instance.write(closest_eV)
-
-    @closest_eV_index.startup
-    async def closest_eV_index(self, instance, value):
-        _, closest_idx = calculator.find_closest_energy(
-            self.current_photon_energy, self.table)
-        await instance.write(closest_idx)

--- a/ioc-satt-dev/db/system.py
+++ b/ioc-satt-dev/db/system.py
@@ -202,4 +202,3 @@ class SystemGroup(PVGroup):
     def __init__(self, prefix, *, ioc, **kwargs):
         super().__init__(prefix, **kwargs)
         self.ioc = ioc
-        self.dt = 0.01

--- a/ioc-satt-dev/satt_app.py
+++ b/ioc-satt-dev/satt_app.py
@@ -74,23 +74,6 @@ class IOCMain(PVGroup):
             T_arr[idx - 1] = filt.transmission.value
         return T_arr
 
-    def _get_config(self, T_des=None):
-        """
-        Return the optimal floor (lower than desired transmission) or ceiling
-        (higher than desired transmission) configuration based on the current
-        mode setting.
-        """
-        if not T_des:
-            T_des = self.sys.t_desired.value
-        mode = self.sys.mode.value
-
-        conf = self.find_configs()
-        config_bestLow, config_bestHigh, T_bestLow, T_bestHigh = conf
-
-        if mode == "Floor":
-            return config_bestLow, T_bestLow, T_des
-        return config_bestHigh, T_bestHigh, T_des
-
 
 def create_ioc(prefix,
                *,

--- a/ioc-satt-dev/satt_app.py
+++ b/ioc-satt-dev/satt_app.py
@@ -1,6 +1,7 @@
 import numpy as np
-from caproto.server import PVGroup
+from caproto.server import PVGroup, SubGroup
 
+from .db.autosave import AutosaveHelper
 from .db.filters import FilterGroup
 from .db.system import SystemGroup
 
@@ -20,6 +21,8 @@ class IOCMain(PVGroup):
             pmps_run=pmps_run,
             pmps_tdes=pmps_tdes,
         )
+
+    autosave_helper = SubGroup(AutosaveHelper)
 
     @property
     def working_filters(self):


### PR DESCRIPTION
Closes #13 

* Simple pvproperty wrapper to mark fields/pvproperties as autosaved
* Appears to work for material, thickness, and is_stuck 👍 

~Will be pushing this back to caproto as an example shortly.~ (see https://github.com/caproto/caproto/pull/617)