### PR TITLE
FIX: one leak mostly down

### DIFF
--- a/ioc-lfe-at2l0-calc/calculator.py
+++ b/ioc-lfe-at2l0-calc/calculator.py
@@ -11,6 +11,7 @@ Atomic Data and Nuclear Data Tables 54 no.2, 181-342 (July 1993).
 B.D. Cullity, Elements of X-Ray Diffraction (Second Edition), 11-20, (1978).
 """
 
+import copy
 import enum
 import functools
 import itertools
@@ -53,9 +54,9 @@ def in_out_combinations(num_blades: int):
 
 class Config:
     def __init__(self, all_transmissions, filter_states, transmission):
-        self.all_transmissions = all_transmissions
-        self.filter_states = filter_states.astype(np.int)
-        self.transmission = transmission
+        self.all_transmissions = copy.copy(all_transmissions)
+        self.filter_states = copy.copy(filter_states)
+        self.transmission = copy.copy(transmission)
 
     def __repr__(self):
         return f'<Config {self.filter_states} transmission={self.transmission}>'
@@ -67,7 +68,7 @@ class Config:
             "-" * width,
             f"Calculated transmission value: {self.transmission}",
             "-" * width,
-            str(self.filter_states.astype(np.int)),
+            str(self.filter_states),
             "=" * width,
         ))
 


### PR DESCRIPTION
Addresses #48 

Ironically (?) making an additional copy reduces leaked memory significantly. I believe this is due to Python holding on to the full numpy arrays (using views for the `Config` values instead of copies).

I still see a small periodic leak as calculations are performed. It's a much smaller amount and more difficult to track down.