### PR TITLE
ENH: first pass at get_ladder_config[s]

### DIFF
--- a/docs/source/algorithm.rst
+++ b/docs/source/algorithm.rst
@@ -73,7 +73,23 @@ For AT2L0, with a desired transmission of ``t_des``,
 Ladder-style algorithm
 ======================
 
-This is not yet implemented.
+The "Best Configuration Algorithm" noted above was designed for AT2L0 and does
+not support ladder-style attenuators such as AT1K3, AT1K4, AT1K2, or AT2K2.
+"Ladder" in this context means that each attenuator blade may have more than
+one filter to choose from, depending on its actuator position.
+
+The generic ladder algorithm ``get_ladder_config`` does its best to
+choose the right filters to target the requested transmission by exhaustively
+listing all possible filter configurations and their resulting transmission
+values.
+
+Similar to the original algorithm's usage of ``argmin``, we use ``argsort``
+determine the 2 closest possible configurations.  The primary difference here
+is slightly more complicated array manipulation.
+
+An additional benefit of the ``argsort`` method is that we can pick the top
+two configurations, and easily figure out which is the floor or ceiling
+configuration.
 
 ESD reference
 =============


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
New algorithm to support more than just in/out filters. This could be considered a generalized version of the _first_ one, which it's loosely based on.

This doesn't take into account material prioritization, which may be a bad thing. I'll need to follow up again as my last question regarding it was ignored. (If it's required for the energy ranges the attenuator will be used in, it's a bit weird that the upstream-most blade would have a silicon filter instead of the downstream-most...)

## Motivation and Context
Closes #16

## How Has This Been Tested?
A bit in the test suite. Have not really verified the results just yet - hopefully they're not wildly off.

Some plots:
![image](https://user-images.githubusercontent.com/5139267/102669561-c180f380-4143-11eb-9cac-a8a2d51ed648.png)
![image](https://user-images.githubusercontent.com/5139267/102669569-c6de3e00-4143-11eb-860a-9a7c3110a8fe.png)


## Where Has This Been Documented?
Basic algorithm documentation