### PR TITLE
BLD: bump requirements and caproto version for OSError fix

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,6 +27,9 @@ test:
     imports:
       - solid_attenuator
       - solid_attenuator.ioc_lfe_at2l0_calc
+      - solid_attenuator.ioc_kfe_at1k4_calc
+      - solid_attenuator.ioc_sim_at2l0
+      - solid_attenuator.ioc_sim_sxr
     requires:
       - pytest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-caproto[standard]>=0.7.0
+caproto[standard]>=0.7.1
 scipy
 periodictable
 psutil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Bump caproto version to v0.7.1. 

## Motivation and Context
This brings in catching the `OSError` that was being raised when our gateway hosts (processes?) were having stability issues. That happened several times and had a weird knock-on effect in which hutch-python profiles were _very_ slow to load (https://github.com/pcdshub/pcdsdevices/issues/735).

## How Has This Been Tested?
Locally and test suite.