### PR TITLE
ENH: add AT2K2 system settings

### DIFF
--- a/AT2K2_sys_settings.sh
+++ b/AT2K2_sys_settings.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+echo "To set production settings, use PREFIX=AT2K2:CALC bash $0"
+
+PREFIX=${PREFIX:=AT2K2:SIM}
+
+echo "Prefix set to: $PREFIX"
+
+set -e
+
+# Corresponds to MMS:01 -> most upstream axis
+# AT2K2 	SN-11343 	1087
+caput ${PREFIX}:AXIS:01:IsStuck 0
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:04:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:04:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:05:Thickness "1.52"
+caput ${PREFIX}:AXIS:01:FILTER:06:Thickness "2.85"
+caput ${PREFIX}:AXIS:01:FILTER:07:Thickness "6.18"
+caput ${PREFIX}:AXIS:01:FILTER:08:Thickness "11.5"
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:04:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:08:Active "True"
+
+# MMS:02
+# AT2K2 	SN-11343 	1088
+caput ${PREFIX}:AXIS:02:IsStuck 0
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:04:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:04:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:05:Thickness "0.78"
+caput ${PREFIX}:AXIS:02:FILTER:06:Thickness "1.52"
+caput ${PREFIX}:AXIS:02:FILTER:07:Thickness "2.85"
+caput ${PREFIX}:AXIS:02:FILTER:08:Thickness "6.18"
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:04:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:08:Active "True"
+
+# MMS:03 -> 2nd to upstream axis
+# AT1K4 	SN-11343 	1086
+caput ${PREFIX}:AXIS:03:IsStuck 0
+
+caput ${PREFIX}:AXIS:03:FILTER:01:Material "Al"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:02:Material "Al"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:03:Material "Al"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:04:Material "Al"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:03:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:03:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:03:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:03:FILTER:01:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:02:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:03:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:04:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:05:Thickness "0.39"
+caput ${PREFIX}:AXIS:03:FILTER:06:Thickness "0.78"
+caput ${PREFIX}:AXIS:03:FILTER:07:Thickness "1.52"
+caput ${PREFIX}:AXIS:03:FILTER:08:Thickness "2.85"
+
+caput ${PREFIX}:AXIS:03:FILTER:01:Active "False"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:02:Active "False"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:03:Active "False"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:04:Active "False"  # not active
+caput ${PREFIX}:AXIS:03:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:03:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:03:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:03:FILTER:08:Active "True"
+
+# MMS:04 -> upstream-most axis
+# AT1K4 	SN-11343 	1089
+caput ${PREFIX}:AXIS:04:IsStuck 0
+
+caput ${PREFIX}:AXIS:04:FILTER:01:Material "Al"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:02:Material "Al"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:03:Material "Al"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:04:Material "Al"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:04:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:04:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:04:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:04:FILTER:01:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:02:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:03:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:04:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:05:Thickness "0.20"
+caput ${PREFIX}:AXIS:04:FILTER:06:Thickness "0.39"
+caput ${PREFIX}:AXIS:04:FILTER:07:Thickness "0.78"
+caput ${PREFIX}:AXIS:04:FILTER:08:Thickness "1.52"
+
+caput ${PREFIX}:AXIS:04:FILTER:01:Active "False"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:02:Active "False"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:03:Active "False"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:04:Active "False"  # not active
+caput ${PREFIX}:AXIS:04:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:04:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:04:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:04:FILTER:08:Active "True"
+
+caput ${PREFIX}:SYS:Run 0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
             # AT2L0 and its simulator:
             'ioc-lfe-at2l0-calc=solid_attenuator.ioc_lfe_at2l0_calc.__main__:main',  # noqa
             'ioc-sim-at2l0=solid_attenuator.ioc_sim_at2l0.__main__:main',
-            # AT1K4 and sxr solid attenuators:
+            # SXR solid attenuator entrypoint, including AT2K2:
+            'ioc-satt-ladder-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
+            # Back-compat for the ioc-kfe-at1k4 entrypoint:
             'ioc-kfe-at1k4-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
             'ioc-sim-sxr-satt=solid_attenuator.ioc_sim_sxr.__main__:main',
             ],

--- a/solid_attenuator/ioc_kfe_at1k4_calc/__main__.py
+++ b/solid_attenuator/ioc_kfe_at1k4_calc/__main__.py
@@ -1,4 +1,19 @@
-import os
+#!/usr/bin/env python3
+"""
+IOC entrypoint for AT1K4.
+
+Also works for:
+
+* AT2K2 (RIX, ioc-rix-at2k2-calc)
+
+Ensure that:
+
+* ``--autosave_path`` and other macros are appropriately customized to
+  avoid shadowing PVs from other IOCs.
+* For production IOCs, the ``--production`` flag is used such that the proper
+  MPS PVs will be chosen, and logging debug flags will be set.
+"""
+
 import sys
 
 from caproto.server import ioc_arg_parser, run
@@ -19,9 +34,9 @@ if '--production' in sys.argv:
     log_level = 'INFO'
     # autosave_path = '/reg/d/iocData/ioc-lfe-at1k4-calc/iocInfo/autosave.json'
     # TODO: wrong env var here; this method is not great:
-    ioc_data = os.environ.get('IOC_DATA_{system}', '/reg/d/iocData/ioc-lfe-at1k4-calc/')  # noqa
+    # ioc_data = os.environ.get('IOC_DATA_SATT', '/reg/d/iocData/ioc-lfe-at1k4-calc/')  # noqa
     # autosave_path = os.path.join(ioc_data, 'autosave.json')
-    autosave_path = 'autosave_development.json'
+    autosave_path = "autosave_development.json"
     sys.argv.remove('--production')
 else:
     subsystem = 'SIM'


### PR DESCRIPTION
Initial settings for AT2K2 based on the same source as https://github.com/pcdshub/lcls-plc-sxr-satt/issues/14

Pairs with https://github.com/pcdshub/lcls-plc-kfe-rix-motion/issues/19
and https://github.com/pcdshub/ioc-rix-at2k2-calc

Item | ax1 | ax2 | ax3 | ax4 | Notes
-- | -- | -- | -- | -- | --
Filter   1 (bottom) | empty | empty | empty | empty |  
Filter 2 | empty | empty | empty | empty |  
Filter   3 | empty | empty | empty | empty |  
Filter 4 | empty | empty | empty | empty |  
Filter   5 | 1.52 | 0.78 | 0.39 | 0.2 |  
Filter 6 | 2.85 | 1.52 | 0.78 | 0.39 |  
Filter   7 | 6.18 | 2.85 | 1.52 | 0.78 |  
Filter 8 (top) | 11.5 | 6.18 | 2.85 | 1.52 |  

