### PR TITLE
ENH: add support for AT1K2 with ioc-kfe-at1k2-calc

### DIFF
--- a/AT1K2_sys_settings.sh
+++ b/AT1K2_sys_settings.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+echo "To set production settings, use PREFIX=AT1K2:CALC bash $0"
+
+PREFIX=${PREFIX:=AT1K2:SIM}
+
+echo "Prefix set to: $PREFIX"
+
+set -e
+
+# Corresponds to MMS:01 -> most upstream axis
+# AT1K2 	SN-11343
+caput ${PREFIX}:AXIS:01:IsStuck 0
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Material "Al"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:04:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:01:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Thickness "0"  # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Thickness "11.5"
+caput ${PREFIX}:AXIS:01:FILTER:04:Thickness "6.18"
+caput ${PREFIX}:AXIS:01:FILTER:05:Thickness "2.85"
+caput ${PREFIX}:AXIS:01:FILTER:06:Thickness "1.52"
+caput ${PREFIX}:AXIS:01:FILTER:07:Thickness "0.78"
+caput ${PREFIX}:AXIS:01:FILTER:08:Thickness "0.39"
+
+caput ${PREFIX}:AXIS:01:FILTER:01:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:02:Active "False" # Not active
+caput ${PREFIX}:AXIS:01:FILTER:03:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:04:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:01:FILTER:08:Active "True"
+
+# MMS:02
+# AT1K2 	SN-11343
+caput ${PREFIX}:AXIS:02:IsStuck 0
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Material "Al"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:04:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:05:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:06:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:07:Material "Al"
+caput ${PREFIX}:AXIS:02:FILTER:08:Material "Al"
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Thickness "0"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Thickness "11.5"
+caput ${PREFIX}:AXIS:02:FILTER:04:Thickness "6.18"
+caput ${PREFIX}:AXIS:02:FILTER:05:Thickness "1.52"
+caput ${PREFIX}:AXIS:02:FILTER:06:Thickness "0.78"
+caput ${PREFIX}:AXIS:02:FILTER:07:Thickness "0.39"
+caput ${PREFIX}:AXIS:02:FILTER:08:Thickness "0.2"
+
+caput ${PREFIX}:AXIS:02:FILTER:01:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:02:Active "False"  # not active
+caput ${PREFIX}:AXIS:02:FILTER:03:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:04:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:05:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:06:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:07:Active "True"
+caput ${PREFIX}:AXIS:02:FILTER:08:Active "True"
+
+caput ${PREFIX}:SYS:Run 0

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,9 @@ setup(
             # AT2L0 and its simulator:
             'ioc-lfe-at2l0-calc=solid_attenuator.ioc_lfe_at2l0_calc.__main__:main',  # noqa
             'ioc-sim-at2l0=solid_attenuator.ioc_sim_at2l0.__main__:main',
-            # SXR solid attenuator entrypoint, including AT2K2:
+            # SXR solid attenuator entrypoint, including AT2K2 and AT1K2:
             'ioc-satt-ladder-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
+            'ioc-kfe-at1k2-calc=solid_attenuator.ioc_kfe_at1k2_calc.__main__:main',
             # Back-compat for the ioc-kfe-at1k4 entrypoint:
             'ioc-kfe-at1k4-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
             'ioc-sim-sxr-satt=solid_attenuator.ioc_sim_sxr.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'ioc-sim-at2l0=solid_attenuator.ioc_sim_at2l0.__main__:main',
             # SXR solid attenuator entrypoint, including AT2K2 and AT1K2:
             'ioc-satt-ladder-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
-            'ioc-kfe-at1k2-calc=solid_attenuator.ioc_kfe_at1k2_calc.__main__:main',
+            'ioc-kfe-at1k2-calc=solid_attenuator.ioc_kfe_at1k2_calc.__main__:main',  # noqa
             # Back-compat for the ioc-kfe-at1k4 entrypoint:
             'ioc-kfe-at1k4-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
             'ioc-sim-sxr-satt=solid_attenuator.ioc_sim_sxr.__main__:main',

--- a/solid_attenuator/ioc_kfe_at1k2_calc/__main__.py
+++ b/solid_attenuator/ioc_kfe_at1k2_calc/__main__.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+IOC entrypoint for AT1K2.
+
+Ensure that:
+
+* ``--autosave_path`` and other macros are appropriately customized to
+  avoid shadowing PVs from other IOCs.
+* For production IOCs, the ``--production`` flag is used such that the proper
+  MPS PVs will be chosen, and logging debug flags will be set.
+"""
+
+import sys
+
+from caproto.server import ioc_arg_parser, run
+
+from .. import util
+from ..sxr import create_ioc
+
+FIRST_FILTER = 1
+NUM_BLADES = 2
+
+
+if '--production' in sys.argv:
+    subsystem = 'CALC'
+    eV_name = "PMPS:KFE:PE:UND:CurrentPhotonEnergy_RBV"
+    pmps_run_name = "PMPS:SXR:{system}:RUN"  # TODO
+    pmps_tdes_name = "PMPS:SXR:{system}:T_DES"  # TODO
+    motor_prefix = "{system}:L2SI:MMS:"  # TODO
+    log_level = 'INFO'
+    # autosave_path = '/reg/d/iocData/ioc-lfe-at1k4-calc/iocInfo/autosave.json'
+    # TODO: wrong env var here; this method is not great:
+    # ioc_data = os.environ.get('IOC_DATA_SATT', '/reg/d/iocData/ioc-lfe-at1k4-calc/')  # noqa
+    # autosave_path = os.path.join(ioc_data, 'autosave.json')
+    autosave_path = "autosave_development.json"
+    sys.argv.remove('--production')
+else:
+    subsystem = 'SIM'
+    eV_name = "LCLS:SXR:BEAM:EV"
+    pmps_run_name = "PMPS:SXR:{system}:RUN"
+    pmps_tdes_name = "PMPS:SXR:{system}:T_DES"
+    motor_prefix = "{system}:SIM:MMS:"
+    autosave_path = 'autosave_development.json'
+    log_level = 'DEBUG'
+
+
+def main():
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="{system}:{subsystem}",
+        desc='Solid attenuator IOC',
+        macros={
+            'system': 'AT1K2',
+            'subsystem': subsystem,
+            'ev_pv': eV_name,
+            'pmps_run_pv': pmps_run_name,
+            'pmps_tdes_pv': pmps_tdes_name,
+            'motor_prefix': motor_prefix,
+            'autosave_path': autosave_path,
+        },
+    )
+
+    ioc = create_ioc(
+        **ioc_options,
+        filter_group={
+            N: f'{N:02d}'
+            for N in range(FIRST_FILTER, NUM_BLADES + FIRST_FILTER)
+        },
+    )
+
+    util.config_logging(ioc.log, level=log_level)
+    run(ioc.pvdb, **run_options)
+
+
+if __name__ == '__main__':
+    main()

--- a/ui/AttenuatorCalculatorSXR_TwoBlade.detailed.ui
+++ b/ui/AttenuatorCalculatorSXR_TwoBlade.detailed.ui
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AttenuatorCalculator</class>
+ <widget class="QWidget" name="AttenuatorCalculator">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1284</width>
+    <height>812</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="PyDMEmbeddedDisplay" name="Overview">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_TwoBlade_overview.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="PyDMEmbeddedDisplay" name="Calculator">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_TwoBlade_calc.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="FilterInfo">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_TwoBlade_filters.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/AttenuatorCalculatorSXR_TwoBlade.ui
+++ b/ui/AttenuatorCalculatorSXR_TwoBlade.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AttenuatorCalculator</class>
+ <widget class="QWidget" name="AttenuatorCalculator">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>672</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="PyDMEmbeddedDisplay" name="Overview">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_FourBlade_overview.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="PyDMEmbeddedDisplay" name="Calculator">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_FourBlade_calc.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/AttenuatorCalculatorSXR_TwoBlade_calc.ui
+++ b/ui/AttenuatorCalculatorSXR_TwoBlade_calc.ui
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AttenuatorCalculator</class>
+ <widget class="QWidget" name="AttenuatorCalculator">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>999</width>
+    <height>686</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,1,1">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>12</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,1,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QGroupBox" name="PhotonEnergyBox">
+        <property name="title">
+         <string>Photon Energy</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="PyDMLabel" name="ActualEnergy">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:ActualPhotonEnergy_RBV </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:ActualPhotonEnergy_RBV </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMEnumButton" name="EnergyEnum">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:EnergySource</string>
+           </property>
+           <property name="items" stdset="0">
+            <stringlist/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLineEdit" name="CustomPhotonEnergy">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="rules" stdset="0">
+            <string>[{&quot;name&quot;: &quot;IfCustom&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;expression&quot;: &quot;ch[0] == 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:EnergySource&quot;, &quot;trigger&quot;: true}]}]</string>
+           </property>
+           <property name="precision" stdset="0">
+            <number>0</number>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:CustomPhotonEnergy</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="TransmissionBox">
+        <property name="title">
+         <string>Transmission</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="PyDMLineEdit" name="DesiredTransmission">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="rules" stdset="0">
+            <string>[]</string>
+           </property>
+           <property name="precision" stdset="0">
+            <number>0</number>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:DesiredTransmission</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="ModeBox">
+        <property name="title">
+         <string>Mode</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="PyDMEnumButton" name="PyDMEnumButton_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:CalcMode</string>
+           </property>
+           <property name="items" stdset="0">
+            <stringlist/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="PyDMPushButton" name="CalculateButton">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Calculate</string>
+     </property>
+     <property name="autoDefault">
+      <bool>true</bool>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:SYS:Run</string>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Calculation Results</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,2,1,0,0,0,0">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>At</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="ActualEnergy_2">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:LastPhotonEnergy_RBV </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:LastPhotonEnergy_RBV </string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>the best configuration for a transmission of</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="PyDMLabel" name="ActualEnergy_3">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:LastTransmission_RBV </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:LastTransmission_RBV </string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>with mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="ActualEnergy_4">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:LastCalcMode_RBV</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:LastCalcMode_RBV</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>is:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMByteIndicator" name="ActiveConfig_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${prefix}:SYS:BestConfigurationBitmask_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="labelPosition" stdset="0">
+         <enum>QTabWidget::South</enum>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>2</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>02</string>
+          <string>01</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame_3">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Estimated transmission error:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="ActualEnergy_5">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:BestConfigError_RBV </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:BestConfigError_RBV </string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMPushButton" name="CalculateButton_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>Apply Configuration</string>
+           </property>
+           <property name="autoDefault">
+            <bool>true</bool>
+           </property>
+           <property name="default">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:ApplyConfiguration</string>
+           </property>
+           <property name="pressValue" stdset="0">
+            <string>1</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumButton</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.enum_button</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/AttenuatorCalculatorSXR_TwoBlade_filters.ui
+++ b/ui/AttenuatorCalculatorSXR_TwoBlade_filters.ui
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>656</width>
+    <height>442</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Filter #</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Material</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Thickness</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Active: blade (or specific filter) should be included in calculations.</string>
+       </property>
+       <property name="text">
+        <string>Active</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Stuck: filters marked as stuck in a certain position will be forced to that state and included in calculations (if active)</string>
+       </property>
+       <property name="text">
+        <string>Stuck</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Transmission</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>3rd Harmonic</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;:&quot;01&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;:&quot;02&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/AttenuatorCalculatorSXR_TwoBlade_overview.ui
+++ b/ui/AttenuatorCalculatorSXR_TwoBlade_overview.ui
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>519</width>
+    <height>203</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMaximumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
+   <property name="topMargin">
+    <number>12</number>
+   </property>
+   <property name="rightMargin">
+    <number>12</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item alignment="Qt::AlignTop">
+    <widget class="QGroupBox" name="FilterStatusGroup">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Filter Status</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6" stretch="1,1">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMaximumSize</enum>
+      </property>
+      <item alignment="Qt::AlignTop">
+       <widget class="PyDMFrame" name="ActiveConfigFrame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMaximumSize</enum>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="PyDMByteIndicator" name="BladeMoving">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Is the filter moving?</string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:FiltersMovingBitmask_RBV</string>
+           </property>
+           <property name="onColor" stdset="0">
+            <color>
+             <red>255</red>
+             <green>208</green>
+             <blue>10</blue>
+            </color>
+           </property>
+           <property name="offColor" stdset="0">
+            <color alpha="0">
+             <red>100</red>
+             <green>100</green>
+             <blue>100</blue>
+            </color>
+           </property>
+           <property name="orientation" stdset="0">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="showLabels" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="bigEndian" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="labelPosition" stdset="0">
+            <enum>QTabWidget::South</enum>
+           </property>
+           <property name="numBits" stdset="0">
+            <number>2</number>
+           </property>
+           <property name="labels" stdset="0">
+            <stringlist>
+             <string>04</string>
+             <string>03</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMByteIndicator" name="ActiveConfig">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>60</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:ActiveConfigurationBitmask_RBV</string>
+           </property>
+           <property name="orientation" stdset="0">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="bigEndian" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="labelPosition" stdset="0">
+            <enum>QTabWidget::South</enum>
+           </property>
+           <property name="numBits" stdset="0">
+            <number>2</number>
+           </property>
+           <property name="labels" stdset="0">
+            <stringlist>
+             <string>02</string>
+             <string>01</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="PyDMLabel" name="Material">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background: black; font: white;</string>
+             </property>
+             <property name="text">
+              <string>ca://${prefix}:AXIS:01:Material</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="showUnits" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://${prefix}:AXIS:01:Material</string>
+             </property>
+             <property name="displayFormat" stdset="0">
+              <enum>PyDMLabel::String</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="PyDMLabel" name="Material_2">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background: black; font: white;</string>
+             </property>
+             <property name="text">
+              <string>ca://${prefix}:AXIS:02:Material</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="showUnits" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://${prefix}:AXIS:02:Material</string>
+             </property>
+             <property name="displayFormat" stdset="0">
+              <enum>PyDMLabel::String</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="PyDMLabel" name="Thickness_2">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background: black; font: white;</string>
+             </property>
+             <property name="text">
+              <string>ca://${prefix}:AXIS:02:Thickness</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="showUnits" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://${prefix}:AXIS:02:Thickness</string>
+             </property>
+             <property name="displayFormat" stdset="0">
+              <enum>PyDMLabel::Decimal</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="PyDMLabel" name="Thickness">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background: black; font: white;</string>
+             </property>
+             <property name="text">
+              <string>ca://${prefix}:AXIS:01:Thickness</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="showUnits" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://${prefix}:AXIS:01:Thickness</string>
+             </property>
+             <property name="displayFormat" stdset="0">
+              <enum>PyDMLabel::Decimal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignTop">
+       <widget class="QFrame" name="TransmissionGroup">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="CurrentLabel">
+           <property name="text">
+            <string>Current transmission:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="CurrentTransmission">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:ActualTransmission_RBV </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:ActualTransmission_RBV </string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="ThirdLabel">
+           <property name="text">
+            <string>Third harmonic:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="CurrentThirdHarmonicTransmission">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>ca://${prefix}:SYS:Actual3OmegaTransmission_RBV</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${prefix}:SYS:Actual3OmegaTransmission_RBV</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMFrame</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.frame</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds ioc entrypoint for AT1K2 and AT1K2 metadata

## Motivation and Context
Required by https://github.com/pcdshub/pcdsdevices/pull/1086

## Where Has This Been Documented?
https://confluence.slac.stanford.edu/display/L2SI/AT1K2-SOLID+SXR+Solid+Attenuator

