### PR TITLE
FIX: Fixing comment about AT1K4 Entrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             # AT2L0 and its simulator:
             'ioc-lfe-at2l0-calc=solid_attenuator.ioc_lfe_at2l0_calc.__main__:main',  # noqa
             'ioc-sim-at2l0=solid_attenuator.ioc_sim_at2l0.__main__:main',
-            # SXR solid attenuator entrypoint, including AT2K2 and AT1K2:
+            # SXR solid attenuator entrypoint, including AT2K2 and AT1K4:
             'ioc-satt-ladder-calc=solid_attenuator.ioc_kfe_at1k4_calc.__main__:main',  # noqa
             'ioc-kfe-at1k2-calc=solid_attenuator.ioc_kfe_at1k2_calc.__main__:main',  # noqa
             # Back-compat for the ioc-kfe-at1k4 entrypoint:


### PR DESCRIPTION
Referencing missed edit from: https://github.com/pcdshub/solid-attenuator/pull/82